### PR TITLE
feat: add deck editor based on simulation results

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,53 @@
+name: Feature
+description: 新機能の追加提案
+title: "feat: "
+labels:
+  - feature
+body:
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景
+      description: なぜ必要か、現在の課題は何か
+      placeholder: 例) シミュレーション結果は表示できるが、デッキ編集に反映できない
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: 目的
+      description: このIssueで達成したいこと
+      placeholder: 例) シミュレーション結果を使ってデッキ案を生成し、手動編集できるようにする
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 受け入れ条件
+      description: 完了判定の条件をチェックリストで記載
+      value: |
+        - [ ] UI上で機能が確認できる
+        - [ ] 主要なバリデーションエラーが表示される
+        - [ ] 既存機能に回帰がない
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: 対象外
+      description: 今回やらないこと
+      placeholder: 例) サーバー保存機能は今回対象外
+    validations:
+      required: false
+  - type: textarea
+    id: task_breakdown
+    attributes:
+      label: 作業分割案
+      description: Sub-issueに分割する単位
+      placeholder: |
+        - UI追加
+        - ロジック追加
+        - テスト
+        - ドキュメント
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Summary
+
+- 
+
+## Related Issue
+
+- Closes #
+
+## Changes
+
+- 
+
+## Test
+
+- [ ] `node --check docs/app.js`
+- [ ] ローカルで `python3 -m http.server 18080 -d docs` を起動して目視確認
+- [ ] 既存機能（シミュレーション結果表示）に回帰がないことを確認
+
+## Risks
+
+- 
+
+## Rollback
+
+- このPRをrevertして復旧可能

--- a/docs/app.js
+++ b/docs/app.js
@@ -14,6 +14,7 @@ const DEFAULT_PACK_PLANS = [
   { packName: "アポカリプス・パクト", count: 20 },
 ];
 const FILTERABLE_CLASS_ORDER = CLASS_ORDER.filter((className) => className !== "ニュートラル");
+const NEUTRAL_CLASS = "ニュートラル";
 const CLASS_COLOR_KEY = {
   エルフ: "elf",
   ロイヤル: "royal",
@@ -40,6 +41,9 @@ const GUARANTEED_RATE_INPUTS = [
   { rarity: LEGEND_RARITY, inputId: "rateGuaranteedLegend" },
 ];
 const OFFICIAL_CARD_URL_PREFIX = "https://shadowverse-wb.com";
+const DEFAULT_DECK_TARGET_CLASS = FILTERABLE_CLASS_ORDER[0];
+const DEFAULT_DECK_TARGET_SIZE = 40;
+const DEFAULT_DECK_CARD_LIMIT = 3;
 
 const state = {
   cards: [],
@@ -47,6 +51,7 @@ const state = {
   cardsByPack: new Map(),
   cardsByPackRarity: new Map(),
   latestResultRows: [],
+  deckByCard: new Map(),
   cardsLastModified: "",
 };
 
@@ -74,6 +79,20 @@ function bindBaseEvents() {
   });
   document.getElementById("resultClassFilter").addEventListener("change", applyResultTableView);
   document.getElementById("resultRaritySort").addEventListener("change", applyResultTableView);
+  document.getElementById("buildDeckFromResult").addEventListener("click", buildDeckFromResult);
+  document.getElementById("clearDeckButton").addEventListener("click", clearDeck);
+  document.getElementById("deckTargetClass").addEventListener("change", renderDeckEditor);
+  document.getElementById("deckTargetSize").addEventListener("change", renderDeckEditor);
+  document.getElementById("deckCardLimit").addEventListener("change", renderDeckEditor);
+  initDeckEditorDefaults();
+}
+
+function initDeckEditorDefaults() {
+  document.getElementById("deckTargetClass").value = DEFAULT_DECK_TARGET_CLASS;
+  document.getElementById("deckTargetSize").value = String(DEFAULT_DECK_TARGET_SIZE);
+  document.getElementById("deckCardLimit").value = String(DEFAULT_DECK_CARD_LIMIT);
+  setDeckMessage("シミュレーション後にデッキ案を生成できます。");
+  renderDeckEditor();
 }
 
 async function loadCardsFromCsv(path) {
@@ -337,8 +356,7 @@ function simulateDraw(setup) {
         addCount(byClass, card.className, 1);
         addCount(byRarity, card.rarity, 1);
 
-        const cardKey =
-          card.cardId || [card.packName, card.cardName, card.className, card.rarity].join("\t");
+        const cardKey = getCardKey(card);
         if (!byCard.has(cardKey)) {
           byCard.set(cardKey, { ...card, count: 0 });
         }
@@ -444,7 +462,10 @@ function renderResults(result) {
     [...result.byRarity.entries()].sort((a, b) => getRarityRank(a[0]) - getRarityRank(b[0])),
   );
   state.latestResultRows = [...result.byCardRows];
+  state.deckByCard = new Map();
+  setDeckMessage("シミュレーション結果を反映しました。デッキ案を生成するか、表の +/- で編集してください。");
   applyResultTableView();
+  renderDeckEditor();
 }
 
 function renderSummaryTable(tbodyId, rows, options = {}) {
@@ -473,6 +494,7 @@ function renderResultRows(rows) {
     const classCell = appendCell(tr, row.className);
     applyClassColor(classCell, row.className);
     appendCell(tr, row.rarity);
+    appendResultActionCell(tr, row);
     tbody.appendChild(tr);
   }
 }
@@ -483,7 +505,7 @@ function applyResultTableView() {
 
   let rows = [...state.latestResultRows];
   if (FILTERABLE_CLASS_ORDER.includes(classFilter)) {
-    rows = rows.filter((row) => row.className === classFilter || row.className === "ニュートラル");
+    rows = rows.filter((row) => row.className === classFilter || row.className === NEUTRAL_CLASS);
   }
 
   if (raritySort === "desc") {
@@ -505,6 +527,272 @@ function applyResultTableView() {
   }
 
   renderResultRows(rows);
+}
+
+function appendResultActionCell(tr, row) {
+  const td = document.createElement("td");
+  td.className = "row-action-cell";
+  const addButton = createRowActionButton("+", "デッキに1枚追加", () => addCardToDeck(row, 1));
+  const removeButton = createRowActionButton(
+    "-",
+    "デッキから1枚削除",
+    () => removeCardFromDeckByKey(getCardKey(row), 1),
+    true,
+  );
+  td.append(addButton, removeButton);
+  tr.appendChild(td);
+  return td;
+}
+
+function appendDeckActionCell(tr, row) {
+  const td = document.createElement("td");
+  td.className = "row-action-cell";
+  const addButton = createRowActionButton("+", "1枚追加", () => addCardToDeck(row, 1));
+  const removeButton = createRowActionButton(
+    "-",
+    "1枚削除",
+    () => removeCardFromDeckByKey(getCardKey(row), 1),
+    true,
+  );
+  td.append(addButton, removeButton);
+  tr.appendChild(td);
+  return td;
+}
+
+function createRowActionButton(label, title, onClick, isDanger = false) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = label;
+  button.title = title;
+  button.className = isDanger ? "row-action-btn is-danger" : "row-action-btn";
+  button.addEventListener("click", onClick);
+  return button;
+}
+
+function collectDeckSetup() {
+  const targetClass = document.getElementById("deckTargetClass").value;
+  const targetSize = Number.parseInt(document.getElementById("deckTargetSize").value, 10);
+  const cardLimit = Number.parseInt(document.getElementById("deckCardLimit").value, 10);
+
+  if (!FILTERABLE_CLASS_ORDER.includes(targetClass)) {
+    return { ok: false, error: "対象クラスを指定してください。" };
+  }
+  if (!Number.isInteger(targetSize) || targetSize <= 0 || targetSize > 80) {
+    return { ok: false, error: "目標デッキ枚数は 1〜80 の整数で指定してください。" };
+  }
+  if (!Number.isInteger(cardLimit) || cardLimit <= 0 || cardLimit > 20) {
+    return { ok: false, error: "同名カード上限は 1〜20 の整数で指定してください。" };
+  }
+
+  return {
+    ok: true,
+    value: {
+      targetClass,
+      targetSize,
+      cardLimit,
+    },
+  };
+}
+
+function buildDeckFromResult() {
+  if (!state.latestResultRows.length) {
+    setDeckMessage("先にシミュレーションを実行してください。", true);
+    return;
+  }
+
+  const setupResult = collectDeckSetup();
+  if (!setupResult.ok) {
+    setDeckMessage(setupResult.error, true);
+    return;
+  }
+  const setup = setupResult.value;
+
+  const candidateRows = state.latestResultRows
+    .filter((row) => isCardAllowedForClass(row, setup.targetClass))
+    .sort((a, b) => {
+      if (b.count !== a.count) {
+        return b.count - a.count;
+      }
+      const rarityDelta = getRarityRank(b.rarity) - getRarityRank(a.rarity);
+      if (rarityDelta !== 0) {
+        return rarityDelta;
+      }
+      return compareCardRows(a, b);
+    });
+
+  state.deckByCard = new Map();
+  let remaining = setup.targetSize;
+
+  for (const row of candidateRows) {
+    const copies = Math.min(row.count, setup.cardLimit, remaining);
+    if (copies <= 0) {
+      continue;
+    }
+    state.deckByCard.set(getCardKey(row), { ...row, count: copies });
+    remaining -= copies;
+    if (remaining === 0) {
+      break;
+    }
+  }
+
+  if (remaining > 0) {
+    setDeckMessage(
+      `候補が不足しているため ${setup.targetSize - remaining}/${setup.targetSize} 枚で生成しました。`,
+      true,
+    );
+  } else {
+    setDeckMessage(`${setup.targetClass} 用のデッキ案を ${setup.targetSize} 枚で生成しました。`);
+  }
+  renderDeckEditor();
+}
+
+function clearDeck() {
+  state.deckByCard = new Map();
+  setDeckMessage("デッキをクリアしました。");
+  renderDeckEditor();
+}
+
+function addCardToDeck(row, copies = 1) {
+  const setupResult = collectDeckSetup();
+  if (!setupResult.ok) {
+    setDeckMessage(setupResult.error, true);
+    return;
+  }
+  const setup = setupResult.value;
+  if (!isCardAllowedForClass(row, setup.targetClass)) {
+    setDeckMessage(`対象外クラスのため追加できません（${setup.targetClass}+${NEUTRAL_CLASS}のみ）。`, true);
+    return;
+  }
+
+  const key = getCardKey(row);
+  const sourceRow = findResultRowByKey(key);
+  if (!sourceRow) {
+    setDeckMessage("このカードは直近シミュレーション結果にないため追加できません。", true);
+    return;
+  }
+
+  const entry = state.deckByCard.get(key) ?? { ...sourceRow, count: 0 };
+  const deckSpace = setup.targetSize - countDeckCards();
+  const remainingByCardLimit = setup.cardLimit - entry.count;
+  const remainingByResultCount = sourceRow.count - entry.count;
+  const addable = Math.min(copies, deckSpace, remainingByCardLimit, remainingByResultCount);
+
+  if (deckSpace <= 0) {
+    setDeckMessage("デッキ枚数が上限です。", true);
+    return;
+  }
+  if (remainingByCardLimit <= 0) {
+    setDeckMessage("同名カード上限に達しています。", true);
+    return;
+  }
+  if (remainingByResultCount <= 0) {
+    setDeckMessage("シミュレーション結果内の所持枚数上限に達しています。", true);
+    return;
+  }
+  if (addable <= 0) {
+    setDeckMessage("追加できませんでした。", true);
+    return;
+  }
+
+  entry.count += addable;
+  state.deckByCard.set(key, entry);
+  if (addable < copies) {
+    setDeckMessage(`${entry.cardName} を ${addable} 枚のみ追加しました。`, true);
+  } else {
+    setDeckMessage(`${entry.cardName} を ${addable} 枚追加しました。`);
+  }
+  renderDeckEditor();
+}
+
+function removeCardFromDeckByKey(cardKey, copies = 1) {
+  const entry = state.deckByCard.get(cardKey);
+  if (!entry) {
+    setDeckMessage("削除対象のカードがデッキにありません。", true);
+    return;
+  }
+  const removedCount = Math.min(copies, entry.count);
+  entry.count -= copies;
+  if (entry.count <= 0) {
+    state.deckByCard.delete(cardKey);
+  } else {
+    state.deckByCard.set(cardKey, entry);
+  }
+  setDeckMessage(`${entry.cardName} を ${removedCount} 枚削除しました。`);
+  renderDeckEditor();
+}
+
+function renderDeckEditor() {
+  const setupResult = collectDeckSetup();
+  const targetSize = setupResult.ok ? setupResult.value.targetSize : 0;
+  const totalCards = countDeckCards();
+  const remainingCards = Math.max(0, targetSize - totalCards);
+
+  document.getElementById("deckTotalCards").textContent = String(totalCards);
+  document.getElementById("deckRemainingCards").textContent = setupResult.ok ? String(remainingCards) : "-";
+  document.getElementById("deckUniqueCards").textContent = String(state.deckByCard.size);
+
+  const byClass = new Map();
+  const byRarity = new Map();
+  for (const row of state.deckByCard.values()) {
+    addCount(byClass, row.className, row.count);
+    addCount(byRarity, row.rarity, row.count);
+  }
+
+  renderSummaryTable(
+    "deckClassSummaryBody",
+    [...byClass.entries()].sort((a, b) => {
+      const rankDelta = getClassRank(a[0]) - getClassRank(b[0]);
+      if (rankDelta !== 0) {
+        return rankDelta;
+      }
+      return b[1] - a[1];
+    }),
+    { colorizeClassLabel: true },
+  );
+  renderSummaryTable(
+    "deckRaritySummaryBody",
+    [...byRarity.entries()].sort((a, b) => getRarityRank(a[0]) - getRarityRank(b[0])),
+  );
+
+  renderDeckRows([...state.deckByCard.values()].sort(compareCardRows));
+}
+
+function renderDeckRows(rows) {
+  const tbody = document.getElementById("deckTableBody");
+  tbody.innerHTML = "";
+
+  for (const row of rows) {
+    const tr = document.createElement("tr");
+    appendCell(tr, String(row.count));
+    appendCardCell(tr, row);
+    const classCell = appendCell(tr, row.className);
+    applyClassColor(classCell, row.className);
+    appendCell(tr, row.rarity);
+    appendDeckActionCell(tr, row);
+    tbody.appendChild(tr);
+  }
+}
+
+function setDeckMessage(message, isError = false) {
+  const messageElement = document.getElementById("deckMessage");
+  messageElement.textContent = message;
+  messageElement.style.color = isError ? "var(--danger)" : "var(--ink-soft)";
+}
+
+function isCardAllowedForClass(row, targetClass) {
+  return row.className === targetClass || row.className === NEUTRAL_CLASS;
+}
+
+function countDeckCards() {
+  let total = 0;
+  for (const row of state.deckByCard.values()) {
+    total += row.count;
+  }
+  return total;
+}
+
+function findResultRowByKey(cardKey) {
+  return state.latestResultRows.find((row) => getCardKey(row) === cardKey) ?? null;
 }
 
 function appendCell(tr, text) {
@@ -591,6 +879,10 @@ function clearError() {
 
 function addCount(map, key, count) {
   map.set(key, (map.get(key) ?? 0) + count);
+}
+
+function getCardKey(card) {
+  return card.cardId || [card.packName, card.cardName, card.className, card.rarity].join("\t");
 }
 
 function cleanValue(value) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -183,9 +183,95 @@
                 <th>カード名</th>
                 <th>クラス</th>
                 <th>レアリティ</th>
+                <th>操作</th>
               </tr>
             </thead>
             <tbody id="resultTableBody"></tbody>
+          </table>
+        </div>
+
+        <h3>3. デッキ編集</h3>
+        <p class="help-text result-help">
+          シミュレーション結果のカードを使って、クラス指定のデッキ案を生成し、そのまま微調整できます。
+        </p>
+        <div class="deck-toolbar">
+          <label class="field">
+            <span>対象クラス</span>
+            <select id="deckTargetClass">
+              <option value="エルフ">エルフ + ニュートラル</option>
+              <option value="ロイヤル">ロイヤル + ニュートラル</option>
+              <option value="ウィッチ">ウィッチ + ニュートラル</option>
+              <option value="ドラゴン">ドラゴン + ニュートラル</option>
+              <option value="ナイトメア">ナイトメア + ニュートラル</option>
+              <option value="ビショップ">ビショップ + ニュートラル</option>
+              <option value="ネメシス">ネメシス + ニュートラル</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>目標デッキ枚数</span>
+            <input id="deckTargetSize" type="number" min="1" max="80" step="1" value="40" />
+          </label>
+          <label class="field">
+            <span>同名カード上限</span>
+            <input id="deckCardLimit" type="number" min="1" max="20" step="1" value="3" />
+          </label>
+        </div>
+        <div class="deck-actions">
+          <button id="buildDeckFromResult" type="button" class="secondary-btn">
+            結果からデッキ案を生成
+          </button>
+          <button id="clearDeckButton" type="button" class="danger-btn">デッキをクリア</button>
+        </div>
+        <p id="deckMessage" class="help-text"></p>
+
+        <div class="stats deck-stats">
+          <div class="stat-card">
+            <div class="stat-label">デッキ枚数</div>
+            <div id="deckTotalCards" class="stat-value">0</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-label">残り枠</div>
+            <div id="deckRemainingCards" class="stat-value">0</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-label">採用カード種類数</div>
+            <div id="deckUniqueCards" class="stat-value">0</div>
+          </div>
+        </div>
+
+        <div class="summary-grid deck-summary-grid">
+          <article class="summary-card">
+            <h3>デッキ内クラス別</h3>
+            <table>
+              <thead>
+                <tr><th>クラス</th><th>枚数</th></tr>
+              </thead>
+              <tbody id="deckClassSummaryBody"></tbody>
+            </table>
+          </article>
+          <article class="summary-card">
+            <h3>デッキ内レアリティ別</h3>
+            <table>
+              <thead>
+                <tr><th>レアリティ</th><th>枚数</th></tr>
+              </thead>
+              <tbody id="deckRaritySummaryBody"></tbody>
+            </table>
+          </article>
+        </div>
+
+        <div class="table-wrap">
+          <table class="result-table deck-table">
+            <thead>
+              <tr>
+                <th>枚数</th>
+                <th>カード名</th>
+                <th>クラス</th>
+                <th>レアリティ</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody id="deckTableBody"></tbody>
           </table>
         </div>
       </section>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -284,6 +284,10 @@ button {
   margin-bottom: 12px;
 }
 
+.deck-summary-grid {
+  grid-template-columns: repeat(2, 1fr);
+}
+
 .summary-card {
   border: 1px solid #d8e4e0;
   border-radius: 12px;
@@ -296,6 +300,24 @@ button {
   gap: 10px;
   grid-template-columns: repeat(2, minmax(220px, 1fr));
   margin: 8px 0 0;
+}
+
+.deck-toolbar {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(200px, 1fr));
+  margin: 8px 0 0;
+}
+
+.deck-actions {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.deck-stats {
+  margin-top: 10px;
 }
 
 .result-help {
@@ -378,6 +400,37 @@ th {
   min-width: 700px;
 }
 
+.deck-table {
+  min-width: 620px;
+}
+
+.row-action-cell {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.row-action-btn {
+  height: 28px;
+  min-width: 30px;
+  padding: 0 8px;
+  border-radius: 8px;
+  font-size: 0.86rem;
+  font-weight: 700;
+  background: #dff3ee;
+  color: #135a4b;
+}
+
+.row-action-btn.is-danger {
+  background: #ffe6ea;
+  color: var(--danger);
+}
+
+.row-action-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .site-footer {
   margin-top: 8px;
   padding: 14px 16px;
@@ -445,6 +498,10 @@ th {
   .rate-grid {
     grid-template-columns: repeat(2, minmax(120px, 1fr));
   }
+
+  .deck-toolbar {
+    grid-template-columns: repeat(2, minmax(180px, 1fr));
+  }
 }
 
 @media (max-width: 700px) {
@@ -452,7 +509,8 @@ th {
     grid-template-columns: 1fr;
   }
 
-  .result-toolbar {
+  .result-toolbar,
+  .deck-toolbar {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- シミュレーション結果をもとにデッキ編集できるUI/ロジックを追加
- 結果テーブルに `+/-` 操作を追加し、デッキへ直接反映可能にした
- Issue/PRベース運用のためのテンプレートを追加

## Related Issue
- Closes #6 

## Changes
- `docs/index.html`
  - 結果テーブルに「操作」列を追加
  - 「3. デッキ編集」セクションを追加（対象クラス/目標枚数/同名上限、生成・クリア、統計、デッキ表）
- `docs/app.js`
  - デッキ状態管理を追加（`deckByCard`）
  - 結果からのデッキ案生成ロジックを追加
  - 結果表/デッキ表での `+/-` 編集を追加
  - デッキ統計（合計、残り枠、種類数、クラス別、レアリティ別）描画を追加
- `docs/styles.css`
  - デッキ編集セクションと行内操作ボタンのスタイルを追加
- `.github/ISSUE_TEMPLATE/feature.yml`
  - Feature Issueテンプレートを追加
- `.github/PULL_REQUEST_TEMPLATE.md`
  - PRテンプレートを追加

## Screenshots
<img width="2552" height="1730" alt="スクリーンショット 2026-04-27 15 02 17" src="https://github.com/user-attachments/assets/d08f912e-5fce-4518-80a7-05ca36a393ed" />

## Test
- [x] `node --check docs/app.js`
- [x] 必須ファイル存在チェック/CSV整合チェック（CI相当のローカル確認）
- [x] ローカル目視確認（`python3 -m http.server 18080 -d docs`）

## Risks
- デッキ案生成の優先度は「出現枚数優先 + レアリティ優先」の暫定ルール
- 将来的にデッキ構築ルール（上限/クラス制約）が変わる場合はロジック調整が必要

## Rollback
- 本PRをrevertすれば機能追加前の状態へ戻せる
