### PR TITLE
feat: add drag-and-drop deck editor

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -44,6 +44,7 @@ const OFFICIAL_CARD_URL_PREFIX = "https://shadowverse-wb.com";
 const DEFAULT_DECK_TARGET_CLASS = FILTERABLE_CLASS_ORDER[0];
 const DEFAULT_DECK_TARGET_SIZE = 40;
 const DEFAULT_DECK_CARD_LIMIT = 3;
+const CARD_DRAG_MIME_TYPE = "application/x-svwb-card";
 
 const state = {
   cards: [],
@@ -53,6 +54,7 @@ const state = {
   latestResultRows: [],
   deckByCard: new Map(),
   cardsLastModified: "",
+  activeDragPayload: null,
 };
 
 document.addEventListener("DOMContentLoaded", init);
@@ -84,6 +86,8 @@ function bindBaseEvents() {
   document.getElementById("deckTargetClass").addEventListener("change", renderDeckEditor);
   document.getElementById("deckTargetSize").addEventListener("change", renderDeckEditor);
   document.getElementById("deckCardLimit").addEventListener("change", renderDeckEditor);
+  document.getElementById("mobileDeckJump").addEventListener("click", scrollToDeckDropZone);
+  initDeckDragAndDrop();
   initDeckEditorDefaults();
 }
 
@@ -463,7 +467,7 @@ function renderResults(result) {
   );
   state.latestResultRows = [...result.byCardRows];
   state.deckByCard = new Map();
-  setDeckMessage("シミュレーション結果を反映しました。デッキ案を生成するか、表の +/- で編集してください。");
+  setDeckMessage("シミュレーション結果を反映しました。デッキ案を生成するか、カードをドラッグして編集してください。");
   applyResultTableView();
   renderDeckEditor();
 }
@@ -494,7 +498,6 @@ function renderResultRows(rows) {
     const classCell = appendCell(tr, row.className);
     applyClassColor(classCell, row.className);
     appendCell(tr, row.rarity);
-    appendResultActionCell(tr, row);
     tbody.appendChild(tr);
   }
 }
@@ -527,46 +530,6 @@ function applyResultTableView() {
   }
 
   renderResultRows(rows);
-}
-
-function appendResultActionCell(tr, row) {
-  const td = document.createElement("td");
-  td.className = "row-action-cell";
-  const addButton = createRowActionButton("+", "デッキに1枚追加", () => addCardToDeck(row, 1));
-  const removeButton = createRowActionButton(
-    "-",
-    "デッキから1枚削除",
-    () => removeCardFromDeckByKey(getCardKey(row), 1),
-    true,
-  );
-  td.append(addButton, removeButton);
-  tr.appendChild(td);
-  return td;
-}
-
-function appendDeckActionCell(tr, row) {
-  const td = document.createElement("td");
-  td.className = "row-action-cell";
-  const addButton = createRowActionButton("+", "1枚追加", () => addCardToDeck(row, 1));
-  const removeButton = createRowActionButton(
-    "-",
-    "1枚削除",
-    () => removeCardFromDeckByKey(getCardKey(row), 1),
-    true,
-  );
-  td.append(addButton, removeButton);
-  tr.appendChild(td);
-  return td;
-}
-
-function createRowActionButton(label, title, onClick, isDanger = false) {
-  const button = document.createElement("button");
-  button.type = "button";
-  button.textContent = label;
-  button.title = title;
-  button.className = isDanger ? "row-action-btn is-danger" : "row-action-btn";
-  button.addEventListener("click", onClick);
-  return button;
 }
 
 function collectDeckSetup() {
@@ -730,6 +693,7 @@ function renderDeckEditor() {
   document.getElementById("deckTotalCards").textContent = String(totalCards);
   document.getElementById("deckRemainingCards").textContent = setupResult.ok ? String(remainingCards) : "-";
   document.getElementById("deckUniqueCards").textContent = String(state.deckByCard.size);
+  updateMobileDeckSummary(setupResult, totalCards, remainingCards);
 
   const byClass = new Map();
   const byRarity = new Map();
@@ -754,7 +718,267 @@ function renderDeckEditor() {
     [...byRarity.entries()].sort((a, b) => getRarityRank(a[0]) - getRarityRank(b[0])),
   );
 
+  renderDeckBuilder(setupResult, totalCards, remainingCards);
   renderDeckRows([...state.deckByCard.values()].sort(compareCardRows));
+}
+
+function renderDeckBuilder(setupResult, totalCards, remainingCards) {
+  const sourceCards = document.getElementById("deckSourceCards");
+  const deckCards = document.getElementById("deckCards");
+  sourceCards.innerHTML = "";
+  deckCards.innerHTML = "";
+
+  const sourceRows = setupResult.ok
+    ? state.latestResultRows
+        .filter((row) => isCardAllowedForClass(row, setupResult.value.targetClass))
+        .sort(compareCardRows)
+    : [];
+  const deckRows = [...state.deckByCard.values()].sort(compareCardRows);
+
+  document.getElementById("deckSourceCount").textContent = `${sourceRows.length} 種類`;
+  document.getElementById("deckDropCount").textContent = `${totalCards} 枚 / 残り ${remainingCards}`;
+
+  if (!state.latestResultRows.length) {
+    sourceCards.appendChild(createDeckPlaceholder("シミュレーション後に表示されます。"));
+  } else if (!sourceRows.length) {
+    sourceCards.appendChild(createDeckPlaceholder("対象クラスの候補がありません。"));
+  } else {
+    for (const row of sourceRows) {
+      const cardKey = getCardKey(row);
+      const deckCount = state.deckByCard.get(cardKey)?.count ?? 0;
+      const availableCount = row.count - deckCount;
+      sourceCards.appendChild(
+        createDeckCardItem(row, {
+          countLabel: `残 ${Math.max(0, availableCount)} / 所持 ${row.count}`,
+          dragSource: "result",
+          isDisabled: availableCount <= 0,
+          actionLabel: "+",
+          actionTitle: "デッキに1枚追加",
+          onAction: () => addCardToDeck(row, 1),
+        }),
+      );
+    }
+  }
+
+  if (!deckRows.length) {
+    deckCards.appendChild(createDeckPlaceholder("カード未選択"));
+  } else {
+    for (const row of deckRows) {
+      deckCards.appendChild(
+        createDeckCardItem(row, {
+          countLabel: `${row.count} 枚`,
+          dragSource: "deck",
+          isDanger: true,
+          actionLabel: "-",
+          actionTitle: "デッキから1枚削除",
+          onAction: () => removeCardFromDeckByKey(getCardKey(row), 1),
+        }),
+      );
+    }
+  }
+}
+
+function updateMobileDeckSummary(setupResult, totalCards, remainingCards) {
+  const summaryText = document.getElementById("mobileDeckSummaryText");
+  if (!setupResult.ok) {
+    summaryText.textContent = `デッキ ${totalCards} 枚`;
+    return;
+  }
+  summaryText.textContent = `デッキ ${totalCards}/${setupResult.value.targetSize} / 残り ${remainingCards}`;
+}
+
+function scrollToDeckDropZone() {
+  const dropZone = document.getElementById("deckDropZone");
+  const top = dropZone.getBoundingClientRect().top + window.scrollY - 12;
+  window.scrollTo({
+    top: Math.max(0, top),
+    behavior: "smooth",
+  });
+}
+
+function createDeckPlaceholder(message) {
+  const placeholder = document.createElement("p");
+  placeholder.className = "deck-card-placeholder";
+  placeholder.textContent = message;
+  return placeholder;
+}
+
+function createDeckCardItem(row, options) {
+  const {
+    countLabel,
+    dragSource,
+    isDisabled = false,
+    isDanger = false,
+    actionLabel,
+    actionTitle,
+    onAction,
+  } = options;
+  const cardKey = getCardKey(row);
+  const item = document.createElement("article");
+  item.className = "deck-card";
+  item.role = "listitem";
+  item.draggable = !isDisabled;
+  item.dataset.cardKey = cardKey;
+  item.dataset.dragSource = dragSource;
+  item.classList.toggle("is-disabled", isDisabled);
+  item.addEventListener("dragstart", (event) => {
+    if (isDisabled) {
+      event.preventDefault();
+      return;
+    }
+    handleCardDragStart(event, { source: dragSource, cardKey });
+  });
+  item.addEventListener("dragend", handleCardDragEnd);
+
+  const topLine = document.createElement("div");
+  topLine.className = "deck-card-topline";
+
+  const count = document.createElement("span");
+  count.className = "deck-card-count";
+  count.textContent = countLabel;
+
+  const actionButton = document.createElement("button");
+  actionButton.type = "button";
+  actionButton.className = isDanger ? "deck-card-action is-danger" : "deck-card-action";
+  actionButton.textContent = actionLabel;
+  actionButton.dataset.symbol = actionLabel;
+  actionButton.title = actionTitle;
+  actionButton.setAttribute("aria-label", `${row.cardName}を${actionTitle}`);
+  actionButton.disabled = isDisabled;
+  actionButton.addEventListener("click", onAction);
+
+  topLine.append(count, actionButton);
+
+  const name = document.createElement("div");
+  name.className = "deck-card-name";
+  name.textContent = row.cardName;
+
+  const meta = document.createElement("div");
+  meta.className = "deck-card-meta";
+  const classBadge = document.createElement("span");
+  classBadge.className = "deck-card-class";
+  classBadge.textContent = row.className;
+  applyClassColor(classBadge, row.className);
+  const rarityBadge = document.createElement("span");
+  rarityBadge.className = "deck-card-rarity";
+  rarityBadge.textContent = row.rarity;
+  rarityBadge.dataset.shortLabel = getShortRarityLabel(row.rarity);
+  meta.append(classBadge, rarityBadge);
+
+  item.append(topLine, name, meta);
+  return item;
+}
+
+function getShortRarityLabel(rarity) {
+  if (rarity === "ブロンズレア") {
+    return "ブロンズ";
+  }
+  if (rarity === "シルバーレア") {
+    return "シルバー";
+  }
+  if (rarity === "ゴールドレア") {
+    return "ゴールド";
+  }
+  return rarity;
+}
+
+function initDeckDragAndDrop() {
+  bindDeckDropRegion(document.getElementById("deckDropZone"), "deck");
+  bindDeckDropRegion(document.getElementById("deckSourceCards"), "source");
+}
+
+function bindDeckDropRegion(element, target) {
+  element.addEventListener("dragenter", (event) => handleDeckDragEnter(event, target, element));
+  element.addEventListener("dragover", (event) => handleDeckDragOver(event, target, element));
+  element.addEventListener("dragleave", (event) => handleDeckDragLeave(event, element));
+  element.addEventListener("drop", (event) => handleDeckDrop(event, target, element));
+}
+
+function handleCardDragStart(event, payload) {
+  state.activeDragPayload = payload;
+  event.dataTransfer.effectAllowed = payload.source === "result" ? "copy" : "move";
+  const payloadText = JSON.stringify(payload);
+  event.dataTransfer.setData(CARD_DRAG_MIME_TYPE, payloadText);
+  event.dataTransfer.setData("text/plain", payloadText);
+  event.currentTarget.classList.add("is-dragging");
+}
+
+function handleCardDragEnd(event) {
+  state.activeDragPayload = null;
+  event.currentTarget.classList.remove("is-dragging");
+  clearDeckDropState();
+}
+
+function handleDeckDragEnter(event, target, element) {
+  if (!canDropDeckPayload(state.activeDragPayload, target)) {
+    return;
+  }
+  event.preventDefault();
+  element.classList.add("is-drop-ready");
+}
+
+function handleDeckDragOver(event, target, element) {
+  if (!canDropDeckPayload(state.activeDragPayload, target)) {
+    return;
+  }
+  event.preventDefault();
+  event.dataTransfer.dropEffect = target === "deck" ? "copy" : "move";
+  element.classList.add("is-drop-ready");
+}
+
+function handleDeckDragLeave(event, element) {
+  if (element.contains(event.relatedTarget)) {
+    return;
+  }
+  element.classList.remove("is-drop-ready");
+}
+
+function handleDeckDrop(event, target, element) {
+  const payload = readDeckDragPayload(event);
+  if (!canDropDeckPayload(payload, target)) {
+    return;
+  }
+  event.preventDefault();
+  element.classList.remove("is-drop-ready");
+
+  if (target === "deck") {
+    const row = findResultRowByKey(payload.cardKey);
+    if (row) {
+      addCardToDeck(row, 1);
+    }
+    return;
+  }
+
+  removeCardFromDeckByKey(payload.cardKey, 1);
+}
+
+function readDeckDragPayload(event) {
+  const payloadText =
+    event.dataTransfer.getData(CARD_DRAG_MIME_TYPE) || event.dataTransfer.getData("text/plain");
+  if (!payloadText) {
+    return state.activeDragPayload;
+  }
+  try {
+    return JSON.parse(payloadText);
+  } catch {
+    return state.activeDragPayload;
+  }
+}
+
+function canDropDeckPayload(payload, target) {
+  if (!payload?.cardKey) {
+    return false;
+  }
+  return (
+    (target === "deck" && payload.source === "result") ||
+    (target === "source" && payload.source === "deck")
+  );
+}
+
+function clearDeckDropState() {
+  document.querySelectorAll(".deck-drop-region.is-drop-ready").forEach((element) => {
+    element.classList.remove("is-drop-ready");
+  });
 }
 
 function renderDeckRows(rows) {
@@ -768,7 +992,6 @@ function renderDeckRows(rows) {
     const classCell = appendCell(tr, row.className);
     applyClassColor(classCell, row.className);
     appendCell(tr, row.rarity);
-    appendDeckActionCell(tr, row);
     tbody.appendChild(tr);
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
       content="SVWBのパック開封をシミュレーションできる非公式ファンサイトです。"
     />
     <meta name="robots" content="index,follow" />
-    <link rel="stylesheet" href="./styles.css?v=20260421d" />
+    <link rel="stylesheet" href="./styles.css?v=20260428b" />
   </head>
   <body>
     <div class="ambient ambient-left"></div>
@@ -183,7 +183,6 @@
                 <th>カード名</th>
                 <th>クラス</th>
                 <th>レアリティ</th>
-                <th>操作</th>
               </tr>
             </thead>
             <tbody id="resultTableBody"></tbody>
@@ -223,6 +222,28 @@
           <button id="clearDeckButton" type="button" class="danger-btn">デッキをクリア</button>
         </div>
         <p id="deckMessage" class="help-text"></p>
+
+        <div class="mobile-deck-summary" aria-live="polite">
+          <span id="mobileDeckSummaryText">デッキ 0/40 / 残り 40</span>
+          <button id="mobileDeckJump" type="button">デッキを見る</button>
+        </div>
+
+        <div class="deck-builder" aria-label="デッキ編集">
+          <section class="deck-card-panel" aria-labelledby="deckSourceTitle">
+            <div class="deck-panel-heading">
+              <h4 id="deckSourceTitle">開封結果</h4>
+              <span id="deckSourceCount" class="deck-panel-count">0 種類</span>
+            </div>
+            <div id="deckSourceCards" class="deck-card-grid deck-drop-region" role="list"></div>
+          </section>
+          <section id="deckDropZone" class="deck-card-panel deck-drop-region" aria-labelledby="deckDropTitle">
+            <div class="deck-panel-heading">
+              <h4 id="deckDropTitle">デッキ</h4>
+              <span id="deckDropCount" class="deck-panel-count">0 枚</span>
+            </div>
+            <div id="deckCards" class="deck-card-grid" role="list"></div>
+          </section>
+        </div>
 
         <div class="stats deck-stats">
           <div class="stat-card">
@@ -268,7 +289,6 @@
                 <th>カード名</th>
                 <th>クラス</th>
                 <th>レアリティ</th>
-                <th>操作</th>
               </tr>
             </thead>
             <tbody id="deckTableBody"></tbody>
@@ -315,6 +335,6 @@
       </div>
     </template>
 
-    <script src="./app.js?v=20260422a" defer></script>
+    <script src="./app.js?v=20260428b" defer></script>
   </body>
 </html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -316,6 +316,184 @@ button {
   gap: 8px;
 }
 
+.mobile-deck-summary {
+  display: none;
+}
+
+.deck-builder {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  margin-top: 12px;
+}
+
+.deck-card-panel {
+  min-height: 220px;
+  border: 1px solid #d8e4e0;
+  border-radius: 12px;
+  background: #f8fcfb;
+  padding: 10px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.deck-drop-region.is-drop-ready {
+  border-color: var(--accent);
+  background: #ecfaf6;
+  box-shadow: inset 0 0 0 2px rgba(15, 138, 112, 0.18);
+}
+
+.deck-panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.deck-panel-heading h4 {
+  margin: 0;
+  font-size: 0.96rem;
+}
+
+.deck-panel-count {
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+.deck-card-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  align-content: start;
+}
+
+.deck-card {
+  position: relative;
+  display: grid;
+  gap: 7px;
+  min-height: 112px;
+  border: 1px solid #cfddd9;
+  border-radius: 8px;
+  background: #fff;
+  padding: 8px;
+  cursor: grab;
+  user-select: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease,
+    transform 0.15s ease;
+}
+
+.deck-card:hover {
+  border-color: #a9c8c0;
+  box-shadow: 0 8px 18px rgba(23, 57, 50, 0.08);
+}
+
+.deck-card.is-dragging {
+  opacity: 0.45;
+  transform: scale(0.98);
+}
+
+.deck-card.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.deck-card-topline,
+.deck-card-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.deck-card-count {
+  display: block;
+  overflow: hidden;
+  max-width: calc(100% - 42px);
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  font-weight: 700;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.deck-card-action {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  width: 50%;
+  min-width: 44px;
+  height: 50%;
+  min-height: 44px;
+  border-radius: 8px;
+  background: transparent;
+  color: transparent;
+  font-size: 0;
+  padding: 8px;
+}
+
+.deck-card-action::after {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #dff3ee;
+  color: #135a4b;
+  content: attr(data-symbol);
+  font-size: 1rem;
+  line-height: 1;
+  place-items: center;
+}
+
+.deck-card-action.is-danger::after {
+  background: #ffe6ea;
+  color: var(--danger);
+}
+
+.deck-card-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.deck-card-name {
+  max-width: calc(100% - 42px);
+  min-height: 2.5em;
+  font-size: 0.9rem;
+  font-weight: 800;
+  line-height: 1.25;
+}
+
+.deck-card-meta {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.deck-card-meta span {
+  border-radius: 999px;
+  padding: 3px 7px;
+  color: var(--ink);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.deck-card-meta span:not(.class-color-cell) {
+  background: #eef4f2;
+  color: var(--ink-soft);
+}
+
+.deck-card-placeholder {
+  margin: 0;
+  padding: 18px 10px;
+  border: 1px dashed #c8d8d3;
+  border-radius: 8px;
+  color: var(--ink-soft);
+  font-size: 0.88rem;
+  text-align: center;
+}
+
 .deck-stats {
   margin-top: 10px;
 }
@@ -397,38 +575,11 @@ th {
 }
 
 .result-table {
-  min-width: 700px;
-}
-
-.deck-table {
   min-width: 620px;
 }
 
-.row-action-cell {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.row-action-btn {
-  height: 28px;
-  min-width: 30px;
-  padding: 0 8px;
-  border-radius: 8px;
-  font-size: 0.86rem;
-  font-weight: 700;
-  background: #dff3ee;
-  color: #135a4b;
-}
-
-.row-action-btn.is-danger {
-  background: #ffe6ea;
-  color: var(--danger);
-}
-
-.row-action-btn:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
+.deck-table {
+  min-width: 520px;
 }
 
 .site-footer {
@@ -502,6 +653,10 @@ th {
   .deck-toolbar {
     grid-template-columns: repeat(2, minmax(180px, 1fr));
   }
+
+  .deck-builder {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 700px) {
@@ -515,10 +670,152 @@ th {
   }
 
   .page {
-    padding: 18px 12px 40px;
+    padding: 18px 12px 104px;
   }
 
   .site-footer {
     padding: 12px;
+  }
+
+  .mobile-deck-summary {
+    position: fixed;
+    right: 12px;
+    bottom: 12px;
+    left: 12px;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    border: 1px solid #bddbd3;
+    border-radius: 12px;
+    background: rgba(248, 252, 251, 0.96);
+    box-shadow: 0 10px 24px rgba(23, 57, 50, 0.16);
+    padding: 8px 8px 8px 12px;
+    color: var(--ink);
+    font-size: 0.9rem;
+    font-weight: 800;
+    backdrop-filter: blur(8px);
+  }
+
+  .mobile-deck-summary button {
+    min-width: 106px;
+    min-height: 44px;
+    height: 44px;
+    border-radius: 10px;
+    background: #dff3ee;
+    color: #135a4b;
+    padding: 0 12px;
+    white-space: nowrap;
+  }
+
+  .deck-card-panel {
+    min-height: 168px;
+    padding: 8px;
+  }
+
+  .deck-card-grid {
+    gap: 6px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .deck-card {
+    position: relative;
+    display: block;
+    min-height: 92px;
+    padding: 8px;
+    touch-action: manipulation;
+  }
+
+  .deck-card-topline {
+    display: block;
+    margin-bottom: 5px;
+  }
+
+  .deck-card-count {
+    display: block;
+    overflow: hidden;
+    max-width: calc(100% - 50px);
+    font-size: 0.78rem;
+    line-height: 1.15;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .deck-card-action {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-end;
+    width: 50%;
+    min-width: 44px;
+    height: 50%;
+    min-height: 44px;
+    border-radius: 8px;
+    background: transparent;
+    color: transparent;
+    font-size: 0;
+    padding: 8px;
+  }
+
+  .deck-card-action::after {
+    display: grid;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: #dff3ee;
+    color: #135a4b;
+    content: attr(data-symbol);
+    font-size: 1.2rem;
+    line-height: 1;
+    place-items: center;
+  }
+
+  .deck-card-action.is-danger::after {
+    background: #ffe6ea;
+    color: var(--danger);
+  }
+
+  .deck-card-name {
+    display: -webkit-box;
+    overflow: hidden;
+    max-width: calc(100% - 50px);
+    min-height: 2.45em;
+    margin-bottom: 6px;
+    font-size: 0.88rem;
+    line-height: 1.22;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .deck-card-meta {
+    flex-wrap: nowrap;
+    gap: 4px;
+    overflow: hidden;
+  }
+
+  .deck-card-meta span {
+    overflow: hidden;
+    max-width: 100%;
+    padding: 2px 6px;
+    font-size: 0.68rem;
+    line-height: 1.35;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .deck-card-meta .deck-card-rarity {
+    font-size: 0;
+  }
+
+  .deck-card-meta .deck-card-rarity::after {
+    content: attr(data-short-label);
+    font-size: 0.68rem;
+  }
+
+  .deck-card-placeholder {
+    padding: 14px 8px;
   }
 }


### PR DESCRIPTION
## Summary

- デッキ編集UIをテーブルの `+ / -` 操作列から、カード型UIベースの編集体験に変更
- 開封結果カードとデッキカードをドラッグ&ドロップで追加/削除できるようにした
- スマホ向けにコンパクトカード表示、固定デッキサマリ、広い `+ / -` タップ領域を追加

Closes #8

## Changes

- `docs/index.html`
  - デッキ編集セクションに「開封結果」「デッキ」のカード型UIを追加
  - スマホ用の固定デッキサマリを追加
  - テーブルの操作列を削除
  - CSS/JSキャッシュバスターを更新

- `docs/app.js`
  - カード型UIの描画処理を追加
  - D&D用の `dragstart` / `dragover` / `drop` 処理を追加
  - 既存の `addCardToDeck` / `removeCardFromDeckByKey` を再利用し、既存制約を維持
  - スマホ固定サマリの更新とデッキ領域へのジャンプを追加

- `docs/styles.css`
  - カードUI、ドロップ領域、ドラッグ中/ドロップ可能状態のスタイルを追加
  - スマホ幅ではカードをコンパクト表示に変更
  - `+ / -` の当たり判定をカード右上1/4に拡大

## Test

- [x] `node --check docs/app.js`
- [x] 必須ファイル存在確認
- [x] CSVヘッダー確認
- [x] `data/svwb_cards_ja.csv` と `docs/data/svwb_cards_ja.csv` の同期確認
- [x] ブラウザでシミュレーション実行を確認
- [x] `+ / -` 操作で追加/削除できることを確認
- [x] 同名カード上限違反時に追加されず、エラーメッセージが出ることを確認
- [x] 「結果からデッキ案を生成」「デッキをクリア」が動作することを確認
- [x] スマホ幅で固定デッキサマリとコンパクトカード表示を確認

## Notes

- スマホではD&Dを補助操作とし、`+ / -` を主操作として使いやすくする方針
- 自動ブラウザ操作ではHTML D&Dの実ドラッグが発火しなかったため、D&Dの最終確認は手動確認ベース
